### PR TITLE
Compatibility for RAP

### DIFF
--- a/com.opcoach.e4.preferences/META-INF/MANIFEST.MF
+++ b/com.opcoach.e4.preferences/META-INF/MANIFEST.MF
@@ -7,12 +7,21 @@ Bundle-Vendor: OPCOACH
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: javax.inject,
  org.eclipse.core.runtime;bundle-version="3.9.0",
- org.eclipse.jface;bundle-version="3.9.0",
  org.eclipse.e4.core.di;bundle-version="1.3.0",
  org.eclipse.e4.ui.model.workbench;bundle-version="1.0.0",
  org.eclipse.e4.core.services;bundle-version="1.1.0",
  org.eclipse.e4.core.contexts;bundle-version="1.3.0",
- org.eclipse.e4.ui.services;bundle-version="1.0.0"
+ org.eclipse.e4.ui.services;bundle-version="1.0.0",
+ org.eclipse.core.commands;bundle-version="3.7.0"
 Export-Package: com.opcoach.e4.preferences,
  com.opcoach.e4.preferences.handlers
 Bundle-ActivationPolicy: lazy
+Import-Package: org.eclipse.jface.databinding.dialog,
+ org.eclipse.jface.dialogs,
+ org.eclipse.jface.preference,
+ org.eclipse.jface.resource,
+ org.eclipse.jface.util,
+ org.eclipse.jface.viewers,
+ org.eclipse.jface.window,
+ org.eclipse.swt,
+ org.eclipse.swt.widgets


### PR DESCRIPTION
Instead of require bundle org.eclipse.jface this change uses import
package dependencies for jface and swt. With this the bundle can be used
in RCP and in RAP.